### PR TITLE
Better Chat Rolls

### DIFF
--- a/module/lasers-and-feelings.js
+++ b/module/lasers-and-feelings.js
@@ -3,18 +3,18 @@
  * @param {integer} num - An integer value found on the Lasers & Feelings character sheet in the number input
  * @param {RollTypes} roleType - Lasers or Feelings roll
  * @param {string} characterName - Name of the character rolling
-*/
+ */
 async function makeRole(diceString, num, roleType, characterName) {
-  let roll = await new Roll(diceString).roll();
-  let chatTemplate = evaluateRolls(roll, num, roleType);
-  roll.toMessage({
-    speaker: { alias: characterName },
-  });
+  let roll = await new Roll(diceString).roll()
+  let chatTemplate = evaluateRolls(roll, num, roleType)
+
   ChatMessage.create({
     content: chatTemplate,
     roll: roll,
+    sound: CONFIG.sounds.dice,
+    type: CONST.CHAT_MESSAGE_TYPES.ROLL,
     speaker: { alias: characterName },
-  });
+  })
 }
 
 /**
@@ -22,124 +22,141 @@ async function makeRole(diceString, num, roleType, characterName) {
  * @param {integer} num - An integer value found on the Lasers & Feelings character sheet in the number input
  * @param {RollTypes} roleType - an integer value of 1 or 0; 1 indicates a Lasers roll, 0 indicates a Feelings roll
  * @returns {string} resultContent - the final string result of number of successes and any Laser-Feelings to be returned
-*/
+ */
 function evaluateRolls(r, num, roleType) {
-  var array = r.terms[0].results;
-  var successCount = 0;
-  var laserFeelingsCount = 0;
-  var resultContent = ``;
+  var successCount = 0
+  var laserFeelingsCount = 0
 
-  array.forEach((element) => {
+  const results = r.dice.flatMap((d) =>
+    d.results.map((result) => result.result),
+  )
+
+  const label =
+    roleType == RollTypes.Lasers
+      ? game.i18n.localize('SIMPLE.LasersRoll')
+      : game.i18n.localize('SIMPLE.FeelingsRoll')
+
+  var resultContent = `<p>${label}</p>`
+  let resultClass = ''
+
+  resultContent += `
+    <div class="dice-tooltip">
+      <ol class="dice-rolls">`
+
+  for (const result of results) {
+    resultClass = ''
     if (
-      (element.result <= num && roleType == RollTypes.Lasers) ||
-      (element.result >= num && roleType == RollTypes.Feelings)
+      (result <= num && roleType == RollTypes.Lasers) ||
+      (result >= num && roleType == RollTypes.Feelings)
     ) {
-      successCount = successCount + 1;
-      if (element.result == num) {
-        laserFeelingsCount = laserFeelingsCount + 1;
+      resultClass = 'success'
+      successCount = successCount + 1
+      if (result == num) {
+        laserFeelingsCount = laserFeelingsCount + 1
       }
     }
-  });
 
-  if (laserFeelingsCount > 0) {
-    resultContent = `
-      <p class="roll success">${game.i18n.localize(
-        "SIMPLE.Successes"
-      )}: ${successCount}</p> 
-      <p class="roll laser-feelings">Laser Feelings: ${laserFeelingsCount}</p>
-    `;
-  } else {
-    resultContent = `
-      <p class="roll success">${game.i18n.localize(
-        "SIMPLE.Successes"
-      )}: ${successCount}</p> 
-    `;
+    resultContent += `<li class="roll die d6 ${resultClass}">${result}</li>`
   }
+  resultContent += `
+      </ol>
+    </div>`
 
-  return resultContent;
+  resultContent += `
+  <p class="roll success">${game.i18n.localize(
+    'SIMPLE.Successes',
+  )}: ${successCount}</p> 
+  `
+
+  if (laserFeelingsCount > 0)
+    resultContent += `
+      <p class="roll laser-feelings">Laser Feelings: ${laserFeelingsCount}</p>
+    `
+
+  return resultContent
 }
 
 /**
  * @param {String} characterName - The name of the character passed in as a string from actor-sheet.js
-*/
+ */
 function lasersRoll(characterName) {
-  let dialogTemplate = game.i18n.localize("SIMPLE.LasersRoll");
-  let thisActor = game.actors.getName(characterName);
-  let num = thisActor.data.data.theOnlyStat;
+  let dialogTemplate = game.i18n.localize('SIMPLE.LasersRoll')
+  let thisActor = game.actors.getName(characterName)
+  let num = thisActor.data.data.theOnlyStat
   new Dialog({
-    title: game.i18n.localize("SIMPLE.LasersRoll"),
+    title: game.i18n.localize('SIMPLE.LasersRoll'),
     content: dialogTemplate,
     buttons: {
       normal: {
         label: game.i18n.localize(Preparedness.Normal),
         callback: () => {
-          makeRole("1d6", num, RollTypes.Lasers, characterName);
+          makeRole('1d6', num, RollTypes.Lasers, characterName)
         },
       },
       prepared: {
         label: game.i18n.localize(Preparedness.Prepared),
         callback: () => {
-          makeRole("2d6", num, RollTypes.Lasers, characterName);
+          makeRole('2d6', num, RollTypes.Lasers, characterName)
         },
       },
       expert: {
         label: game.i18n.localize(Preparedness.Expert),
         callback: () => {
-          makeRole("3d6", num, RollTypes.Lasers, characterName);
+          makeRole('3d6', num, RollTypes.Lasers, characterName)
         },
       },
       close: {
-        label: "Close",
+        label: 'Close',
       },
     },
-  }).render(true);
+  }).render(true)
 }
 
 /**
  * @param {String} characterName - The name of the character passed in as a string from actor-sheet.js
-*/
+ */
 function feelingsRoll(characterName) {
-  let dialogTemplate = game.i18n.localize("SIMPLE.FeelingsRoll");
-  let thisActor = game.actors.getName(characterName);
-  let num = thisActor.data.data.theOnlyStat;
+  let dialogTemplate = game.i18n.localize('SIMPLE.FeelingsRoll')
+  let thisActor = game.actors.getName(characterName)
+  let num = thisActor.data.data.theOnlyStat
   new Dialog({
-    title: game.i18n.localize("SIMPLE.FeelingsRoll"),
+    title: game.i18n.localize('SIMPLE.FeelingsRoll'),
     content: dialogTemplate,
     buttons: {
       normal: {
         label: game.i18n.localize(Preparedness.Normal),
         callback: () => {
-          makeRole("1d6", num, RollTypes.Feelings, characterName);
+          makeRole('1d6', num, RollTypes.Feelings, characterName)
         },
       },
       prepared: {
         label: game.i18n.localize(Preparedness.Prepared),
         callback: () => {
-          makeRole("2d6", num, RollTypes.Feelings, characterName);
+          makeRole('2d6', num, RollTypes.Feelings, characterName)
         },
       },
       expert: {
         label: game.i18n.localize(Preparedness.Expert),
         callback: () => {
-          makeRole("3d6", num, RollTypes.Feelings, characterName);
+          makeRole('3d6', num, RollTypes.Feelings, characterName)
         },
       },
       close: {
-        label: "Close",
+        label: 'Close',
       },
     },
-  }).render(true);
+  }).render(true)
 }
 
 const RollTypes = {
   Lasers: 1,
-  Feelings: 0
-};
+  Feelings: 0,
+}
 
 const Preparedness = {
-  Normal: "SIMPLE.Normal",
-  Prepared: "SIMPLE.Prepared",
-  Expert: "SIMPLE.Expert",
-};
+  Normal: 'SIMPLE.Normal',
+  Prepared: 'SIMPLE.Prepared',
+  Expert: 'SIMPLE.Expert',
+}
 
-export { lasersRoll, feelingsRoll };
+export { lasersRoll, feelingsRoll }

--- a/system.json
+++ b/system.json
@@ -2,14 +2,14 @@
   "id": "laf",
   "title": "Lasers & Feelings",
   "description": "An implementation of the adaptable one-page Lasers & Feelings system by John Harper.",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "compatibility": {
     "minimum": 11,
-    "verified": 11.300
+    "verified": 11.315
   },
   "url": "https://github.com/ElusiveZenith/fvtt-laf",
   "manifest": "https://raw.githubusercontent.com/ElusiveZenith/fvtt-laf/master/system.json",
-  "download": "https://github.com/ElusiveZenith/fvtt-laf/releases/download/2.0.0/system.zip",
+  "download": "https://github.com/ElusiveZenith/fvtt-laf/releases/download/2.1.0/system.zip",
   "templateVersion": 2,
   "author": "ElusiveZenith",
   "authors": [


### PR DESCRIPTION
Chat output when a Lasers or Feelings roll is performed can be confusing. The total displayed is unhelpful, and expanding it to display the actual dice rolls is an additional click.

* Remove default `roll.toMessage()` chat output
* Add the `.dice-tooltip .dice-rolls` list (per the default `toMessage()` output) to the `evaluateRolls` chat message, highlighting success dice
* Add `type: CONST.CHAT_MESSAGE_TYPES.ROLL` to the `ChatMessage.create()` call to allow the correct hooks to fire (allows DiceSoNice! support, for example)
* Add a message indicating the type of roll
* DRY up the `resultContent` generation in `evaluateRolls`

(Also note that there are further changes as a result of my linter rules.)

**Before**

![image](https://github.com/ElusiveZenith/fvtt-laf/assets/305037/de1cd318-e4d5-4699-ae4e-8ebd15f41e10)

**After**

![image](https://github.com/ElusiveZenith/fvtt-laf/assets/305037/e177ff25-5291-452d-9cbb-830f74fff777)
