### PR TITLE
Update item sheet with functional data types, add item list to actor sheet

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -41,5 +41,8 @@
 
   "SIMPLE.Successes": "Successes",
 
-  "SIMPLE.SpaceAdventure": "<h3>Space Adventure Generated:</h3> <strong>{threat}</strong> want(s) to <strong>{wants}</strong> the <strong>{target}</strong>, which will <strong>{result}</strong>."
+  "SIMPLE.SpaceAdventure": "<h3>Space Adventure Generated:</h3> <strong>{threat}</strong> want(s) to <strong>{wants}</strong> the <strong>{target}</strong>, which will <strong>{result}</strong>.",
+
+  "SIMPLE.AttributeValue": "Value",
+  "SIMPLE.AttributeLabel": "Label"
 }

--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -24,8 +24,13 @@ export class SimpleActorSheet extends ActorSheet {
       enrichedNotepad: await TextEditor.enrichHTML(this.document.system.notepad, {async: true, rollData}),
       editable: this.isEditable,
       owner: this.document.isOwner,
-      rollData: rollData
+      rollData: rollData,
+      items: this.document.items.contents
     };
+    data.items.sort((a, b) => {
+      const sort = b.sort - a.sort;
+      return sort ? sort : a.name.localeCompare(b.name);
+    });
     return data;
   }
 
@@ -39,6 +44,22 @@ export class SimpleActorSheet extends ActorSheet {
     html[0].querySelectorAll("input[type=text], input[type=number]").forEach(n => {
       n.addEventListener("focus", (event) => event.currentTarget.select());
     });
+    html[0].querySelectorAll(".item-list [data-action=item]").forEach(n => {
+      n.addEventListener("click", this._onClickItem.bind(this));
+    });
+    html[0].querySelectorAll(".item-list [data-action=delete]").forEach(n => {
+      n.addEventListener("click", this._onClickDeleteItem.bind(this));
+    });
+  }
+
+  async _onClickDeleteItem(event) {
+    const id = event.currentTarget.closest("[data-item-id]").dataset.itemId;
+    return this.document.items.get(id).deleteDialog();
+  }
+
+  async _onClickItem(event) {
+    const id = event.currentTarget.closest("[data-item-id]").dataset.itemId;
+    return this.document.items.get(id).sheet.render(true);
   }
 
   async _onClickRoll(event) {

--- a/module/document-classes.js
+++ b/module/document-classes.js
@@ -1,6 +1,6 @@
 export class ActorLAF extends Actor {
-  async roll(type="laser") {
-    const label = game.i18n.localize(`SIMPLE.${type==="laser" ? "Lasers" : "Feelings"}Roll`);
+  async roll(type = "laser") {
+    const label = game.i18n.localize(`SIMPLE.${type === "laser" ? "Lasers" : "Feelings"}Roll`);
     return Dialog.wait({
       title: label,
       content: `<p>${label}</p>`,
@@ -25,7 +25,7 @@ export class ActorLAF extends Actor {
     });
   }
 
-  async makeRoll(event, {dice="1d6", type="laser"}={}) {
+  async makeRoll(event, {dice = "1d6", type = "laser"} = {}) {
     const roll = await new Roll(dice).evaluate();
 
     let successes = 0;
@@ -34,7 +34,7 @@ export class ActorLAF extends Actor {
     const num = this.system.theOnlyStat;
 
     const results = roll.dice.flatMap(die => die.results.map(r => r.result));
-    const label = game.i18n.localize(`SIMPLE.${type==="laser" ? "Lasers" : "Feelings"}Roll`);
+    const label = game.i18n.localize(`SIMPLE.${type === "laser" ? "Lasers" : "Feelings"}Roll`);
 
     let content = `<p>${label}</p>`;
     content += `<div class="dice-tooltip"><ol class="dice-rolls">`;

--- a/module/init.js
+++ b/module/init.js
@@ -1,5 +1,5 @@
-import { SimpleActorSheet } from "./actor-sheet.js";
-import { SimpleItemSheet } from "./item-sheet.js";
+import {SimpleActorSheet} from "./actor-sheet.js";
+import {SimpleItemSheet} from "./item-sheet.js";
 import * as documents from "./document-classes.js";
 
 /* -------------------------------------------- */
@@ -24,9 +24,9 @@ Hooks.once("init", async function() {
 
   // Register sheet application classes
   Actors.unregisterSheet("core", ActorSheet);
-  Actors.registerSheet("laf", SimpleActorSheet, { makeDefault: true });
+  Actors.registerSheet("laf", SimpleActorSheet, {makeDefault: true});
   Items.unregisterSheet("core", ItemSheet);
-  Items.registerSheet("laf", SimpleItemSheet, { makeDefault: true });
+  Items.registerSheet("laf", SimpleItemSheet, {makeDefault: true});
 
   // Register system settings
   game.settings.register("laf", "macroShorthand", {

--- a/module/item-sheet.js
+++ b/module/item-sheet.js
@@ -5,14 +5,14 @@
 export class SimpleItemSheet extends ItemSheet {
 
   /** @override */
-	static get defaultOptions() {
-	  return foundry.utils.mergeObject(super.defaultOptions, {
-			classes: ["laf", "sheet", "item"],
-			template: "systems/laf/templates/item-sheet.hbs",
-			width: 520,
-			height: 480,
+  static get defaultOptions() {
+    return foundry.utils.mergeObject(super.defaultOptions, {
+      classes: ["laf", "sheet", "item"],
+      template: "systems/laf/templates/item-sheet.hbs",
+      width: 520,
+      height: 480,
       tabs: [{navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "description"}]
-		});
+    });
   }
 
   /* -------------------------------------------- */
@@ -26,15 +26,30 @@ export class SimpleItemSheet extends ItemSheet {
       enrichedDescription: await TextEditor.enrichHTML(this.document.system.description, {async: true, rollData}),
       editable: this.isEditable,
       owner: this.document.isOwner,
-      rollData: rollData
+      rollData: rollData,
+      dtypes: {String: "String", Formula: "Formula", Boolean: "Boolean", Number: "Number", Resource: "Resource"}
     };
+
+    data.attributes = [];
+    for (const [k, v] of Object.entries(this.document.system.attributes)) {
+      const isFormula = v.dtype === "Formula";
+      data.attributes.push({
+        ...v,
+        key: k,
+        isFormula: isFormula,
+        isBoolean: v.dtype === "Boolean",
+        isResource: (v.dtype === "Resource") || (v.dtype === "Number"),
+        value: isFormula ? (Roll.validate(`${v.value}`) ? v.value : "") : v.value
+      });
+    }
+
     return data;
   }
 
   /* -------------------------------------------- */
 
   /** @override */
-  setPosition(options={}) {
+  setPosition(options = {}) {
     const position = super.setPosition(options);
     const sheetBody = this.element.find(".sheet-body");
     const bodyHeight = position.height - 192;
@@ -45,7 +60,7 @@ export class SimpleItemSheet extends ItemSheet {
   /* -------------------------------------------- */
 
   /** @override */
-	activateListeners(html) {
+  activateListeners(html) {
     super.activateListeners(html);
 
     // Everything below here is only needed if the sheet is editable
@@ -56,10 +71,24 @@ export class SimpleItemSheet extends ItemSheet {
     });
 
     // Add or Remove Attribute
-    html.find(".attributes").on("click", ".attribute-control", this._onClickAttributeControl.bind(this));
+    html[0].querySelectorAll(".attribute-control").forEach(n => {
+      n.addEventListener("click", this._onClickAttributeControl.bind(this));
+    });
+
+    html[0].querySelectorAll(".attributes-list .attribute-roll").forEach(n => {
+      n.addEventListener("click", this._onClickAttributeRoll.bind(this));
+    });
   }
 
   /* -------------------------------------------- */
+
+  async _onClickAttributeRoll(event) {
+    const formula = event.currentTarget.dataset.roll;
+    const actor = this.document.actor;
+    const rollData = this.document.getRollData();
+    const speaker = ChatMessage.implementation.getSpeaker({actor: actor});
+    return new Roll(formula, rollData).toMessage({speaker: speaker}, {rollMode: game.settings.get("core", "rollMode")});
+  }
 
   /**
    * Listen for click events on an attribute control to modify the composition of attributes in the sheet
@@ -68,32 +97,24 @@ export class SimpleItemSheet extends ItemSheet {
    */
   async _onClickAttributeControl(event) {
     event.preventDefault();
-    const a = event.currentTarget;
-    const action = a.dataset.action;
-    const attrs = this.object.system.attributes;
-    const form = this.form;
+    const action = event.currentTarget.dataset.action;
 
     // Add new attribute
-    if ( action === "create" ) {
-      const objKeys = Object.keys(attrs);
-      let nk = Object.keys(attrs).length + 1;
+    if (action === "create") {
+      const objKeys = new Set(Object.keys(this.document.system.attributes));
+      let nk = objKeys.size + 1;
       let newValue = `attr${nk}`;
-      let newKey = document.createElement("div");
-      while ( objKeys.includes(newValue) ) {
-        ++nk;
+      while (objKeys.has(newValue)) {
+        nk++;
         newValue = `attr${nk}`;
       }
-      newKey.innerHTML = `<input type="text" name="system.attributes.attr${nk}.key" value="${newValue}"/>`;
-      newKey = newKey.children[0];
-      form.appendChild(newKey);
-      await this._onSubmit(event);
+      this.document.update({[`system.attributes.${newValue}`]: {}});
     }
 
     // Remove existing attribute
-    else if ( action === "delete" ) {
-      const li = a.closest(".attribute");
-      li.parentElement.removeChild(li);
-      await this._onSubmit(event);
+    else if (action === "delete") {
+      const key = event.currentTarget.closest("[data-key]").dataset.key;
+      this.document.update({[`system.attributes.-=${key}`]: null});
     }
   }
 
@@ -103,27 +124,30 @@ export class SimpleItemSheet extends ItemSheet {
   _updateObject(event, formData) {
 
     // Handle the free-form attributes list
-    const formAttrs = expandObject(formData).system.attributes || {};
+    const formAttrs = foundry.utils.expandObject(formData).system.attributes || {};
     const attributes = Object.values(formAttrs).reduce((obj, v) => {
-      let k = v["key"].trim();
-      if ( /[\s\.]/.test(k) )  return ui.notifications.error("Attribute keys may not contain spaces or periods");
-      delete v["key"];
+      const k = v.key.slugify({strict: true}).trim();
+      if (/[\s\.]/.test(k)) {
+        ui.notifications.error("Attribute keys may not contain spaces or periods");
+        return obj;
+      }
+      delete v.key;
       obj[k] = v;
       return obj;
     }, {});
 
     // Remove attributes which are no longer used
-    for ( let k of Object.keys(this.object.system.attributes) ) {
-      if ( !attributes.hasOwnProperty(k) ) attributes[`-=${k}`] = null;
+    for (const k of Object.keys(this.document.system.attributes)) {
+      if (!attributes.hasOwnProperty(k)) attributes[`-=${k}`] = null;
     }
 
     // Re-combine formData
-    formData = Object.entries(formData).filter(e => !e[0].startsWith("system.attributes")).reduce((obj, e) => {
-      obj[e[0]] = e[1];
+    formData = Object.entries(formData).reduce((obj, [k, v]) => {
+      if (!k.startsWith("system.attributes")) obj[k] = v;
       return obj;
-    }, {_id: this.object._id, "system.attributes": attributes});
+    }, {"system.attributes": attributes});
 
     // Update the Item
-    return this.object.update(formData);
+    return this.document.update(formData);
   }
 }

--- a/styles/simple.css
+++ b/styles/simple.css
@@ -12,7 +12,20 @@
   background: url('../assets/greybg.jpg');
   height: 100%;
   padding: 5px;
-  overflow-y: hidden;
+  overflow: hidden;
+
+  & form {
+    height: 100%;
+
+    .sheet-body {
+      height: calc(100% - 100px);
+
+      .body-container {
+        height: 100%;
+        overflow: auto;
+      }
+    }
+  }
 }
 .laf .sheet-header {
   overflow: hidden;
@@ -151,13 +164,14 @@
 }
 .laf .tabs .item {
   border-style: double;
-  line-height: 40px;
+  line-height: 28px;
   font-weight: bold;
 }
 .laf .tabs .item.active {
   text-decoration: underline;
   text-decoration-color: #00aeef;
   text-shadow: none;
+  border-color: #00aeef;
 }
 .laf.sheet.item .resource {
   display: flex;
@@ -178,13 +192,10 @@
 .laf .editor {
   height: 100px;
   border: 2px solid #007dac;
-
 }
 .laf .item-list {
   list-style: none;
-  margin: 7px 0;
   padding: 0;
-  overflow-y: auto;
 }
 .laf .item-list .item {
   min-height: 30px;
@@ -192,13 +203,17 @@
   padding: 3px 0;
   border-bottom: 1px solid #BBB;
   align-items: stretch;
+  display: flex;
 }
 .laf .item-list .item img {
   flex: 0 0 24px;
   margin-right: 5px;
+  border: none;
+  max-width: 24px;
 }
 .laf .item-list .item-name {
   margin: 0;
+  flex: 1;
 }
 .laf .item-list .item-controls {
   flex: 0 0 36px;

--- a/system.json
+++ b/system.json
@@ -2,14 +2,14 @@
   "id": "laf",
   "title": "Lasers & Feelings",
   "description": "An implementation of the adaptable one-page Lasers & Feelings system by John Harper.",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "compatibility": {
     "minimum": 11,
     "verified": 11.315
   },
   "url": "https://github.com/ElusiveZenith/fvtt-laf",
   "manifest": "https://raw.githubusercontent.com/ElusiveZenith/fvtt-laf/master/system.json",
-  "download": "https://github.com/ElusiveZenith/fvtt-laf/releases/download/2.2.0/system.zip",
+  "download": "https://github.com/ElusiveZenith/fvtt-laf/releases/download/2.3.0/system.zip",
   "templateVersion": 2,
   "author": "ElusiveZenith",
   "authors": [

--- a/templates/actor-sheet.hbs
+++ b/templates/actor-sheet.hbs
@@ -33,19 +33,30 @@
         </div>
         <div class="column">
           <div class="bodyfields">
-            <input class="styleinput" name="system.style" type="text" value="{{system.style}}" placeholder="{{localize "SIMPLE.Style"}}">
+            <input class="styleinput" name="system.style" type="text" value="{{system.style}}" placeholder="{{localize 'SIMPLE.Style'}}">
           </div>
           <div class="bodyfields">
-            <input class="roleinput" name="system.role" type="text" value="{{system.role}}" placeholder="{{localize "SIMPLE.Role"}}">
+            <input class="roleinput" name="system.role" type="text" value="{{system.role}}" placeholder="{{localize 'SIMPLE.Role'}}">
           </div>
           <div class="bodyfields">
-            <input class="goalinput" name="system.goal" type="text" value="{{system.goal}}" placeholder="{{localize "SIMPLE.Goal"}}">
+            <input class="goalinput" name="system.goal" type="text" value="{{system.goal}}" placeholder="{{localize 'SIMPLE.Goal'}}">
           </div>
         </div>
       </div>
       <div class="notepad" data-group="primary" data-tab="notepad" placeholder="Notes">
         {{editor enrichedNotepad target="system.notepad" button=true rollData=rollData owner=owner editable=editable engine="prosemirror"}}
       </div>
+      <ul class="item-list">
+        {{#each items as |item|}}
+        <li class="item" data-item-id="{{item.id}}">
+          <img src="{{item.img}}" alt="">
+          <a data-action="item" class="item-name">{{item.name}}</a>
+          <div class="item-controls">
+            <a class="item-control" data-action="delete"><i class="fa-solid fa-trash"></i></a>
+          </div>
+        </li>
+        {{/each}}
+      </ul>
     </div>
   </section>
 </form>

--- a/templates/item-sheet-attributes.hbs
+++ b/templates/item-sheet-attributes.hbs
@@ -1,66 +1,47 @@
 <section class="attributes-group">
   <ol class="attributes-list">
-    {{#each attributes as |attr key|}}
-    <li class="attribute flexrow" data-attribute="{{#if attr.group}}{{attr.group}}.{{/if}}{{key}}">
+    {{#each attributes}}
+    <li class="attribute flexrow" data-attribute="{{#if group}}{{group}}.{{/if}}{{key}}" data-key="{{key}}">
       <div class="attribute-key-wrapper flexrow">
-        {{#if attr.isFormula}}
-        <a class="attribute-roll" data-label="{{attr.label}}" data-roll="{{attr.value}}"><i
-            class="fas fa-dice-d20"></i></a>
+        {{#if isFormula}}
+        <a class="attribute-roll" data-label="{{label}}" data-roll="{{value}}">
+          <i class="fas fa-dice-d20"></i>
+        </a>
         {{/if}}
-        <input class="attribute-key" type="text"
-          name="system.attributes.{{#if attr.group}}{{attr.group}}.{{/if}}{{key}}.key" value="{{key}}"
-          placeholder="{{localize " SIMPLE.AttributeKey"}}" />
+        <input class="attribute-key" type="text" name="system.attributes.{{#if group}}{{group}}.{{/if}}{{key}}.key" value="{{key}}" placeholder="{{localize 'SIMPLE.AttributeKey'}}">
       </div>
       {{!-- Handle booleans. --}}
-      {{#if attr.isCheckbox}}
-      <label class="attribute-value checkbox"><input type="checkbox"
-          name="system.attributes.{{#if attr.group}}{{attr.group}}.{{/if}}{{key}}.value" {{checked
-          attr.value}} /></label>
+      {{#if isBoolean}}
+      <label class="attribute-value checkbox">
+        <input type="checkbox" name="system.attributes.{{#if group}}{{group}}.{{/if}}{{key}}.value" {{checked value}}>
+      </label>
       {{else}}
       {{!-- Handle resources. --}}
-      {{#if attr.isResource}}
+      {{#if isResource}}
       <div class="attribute-group flexrow">
         <span class="attribute-col flexcol">
-          <label for="system.attributes.{{#if attr.group}}{{attr.group}}.{{/if}}{{key}}.min">{{localize
-            "SIMPLE.ResourceMin"}}</label>
-          <input class="attribute-value" type="text"
-            name="system.attributes.{{#if attr.group}}{{attr.group}}.{{/if}}{{key}}.min" value="{{attr.min}}"
-            data-dtype="Number" />
+          <label>{{localize "SIMPLE.ResourceMin"}}</label>
+          <input class="attribute-value" type="number" name="system.attributes.{{#if group}}{{group}}.{{/if}}{{key}}.min" value="{{min}}">
         </span>
         <span class="attribute-col flexcol">
-          <label for="system.attributes.{{#if attr.group}}{{attr.group}}.{{/if}}{{key}}.value">{{localize
-            "SIMPLE.ResourceValue"}}</label>
-          <input class="attribute-value" type="text"
-            name="system.attributes.{{#if attr.group}}{{attr.group}}.{{/if}}{{key}}.value" value="{{attr.value}}"
-            data-dtype="Number" />
+          <label>{{localize "SIMPLE.ResourceValue"}}</label>
+          <input class="attribute-value" type="number" name="system.attributes.{{#if group}}{{group}}.{{/if}}{{key}}.value" value="{{value}}">
         </span>
         <span class="attribute-col flexcol">
-          <label for="system.attributes.{{#if attr.group}}{{attr.group}}.{{/if}}{{key}}.max">{{localize
-            "SIMPLE.ResourceMax"}}</label>
-          <input class="attribute-value" type="text"
-            name="system.attributes.{{#if attr.group}}{{attr.group}}.{{/if}}{{key}}.max" value="{{attr.max}}"
-            data-dtype="Number" />
+          <label>{{localize "SIMPLE.ResourceMax"}}</label>
+          <input class="attribute-value" type="number" name="system.attributes.{{#if group}}{{group}}.{{/if}}{{key}}.max" value="{{max}}">
         </span>
       </div>
       {{!-- Handle other input types. --}}
       {{else}}
-      <input class="attribute-value" type="text"
-        name="system.attributes.{{#if attr.group}}{{attr.group}}.{{/if}}{{key}}.value" value="{{attr.value}}"
-        data-dtype="{{attr.dtype}}" placeholder="{{localize " SIMPLE.AttributeValue"}}" />
+      <input class="attribute-value" type="text" name="system.attributes.{{#if group}}{{group}}.{{/if}}{{key}}.value" value="{{value}}" data-dtype="{{dtype}}" placeholder="{{localize 'SIMPLE.AttributeValue'}}">
       {{/if}}
       {{/if}}
-      <input class="attribute-label" type="text"
-        name="system.attributes.{{#if attr.group}}{{attr.group}}.{{/if}}{{key}}.label" value="{{attr.label}}"
-        placeholder="{{localize " SIMPLE.AttributeLabel"}}" />
-      <select class="attribute-dtype" name="system.attributes.{{#if attr.group}}{{attr.group}}.{{/if}}{{key}}.dtype">
-        {{#select attr.dtype}}
-        {{#each ../dtypes as |t|}}
-        <option value="{{t}}">{{t}}</option>
-        {{/each}}
-        {{/select}}
+      <input class="attribute-label" type="text" name="system.attributes.{{#if group}}{{group}}.{{/if}}{{key}}.label" value="{{label}}" placeholder="{{localize 'SIMPLE.AttributeLabel'}}">
+      <select class="attribute-dtype" name="system.attributes.{{#if group}}{{group}}.{{/if}}{{key}}.dtype">
+        {{selectOptions @root.dtypes selected=dtype blank="" sort=true}}
       </select>
-      <input type="hidden" name="system.attributes.{{#if attr.group}}{{attr.group}}.{{/if}}{{key}}.group"
-        value="{{attr.group}}" />
+      <input type="hidden" name="system.attributes.{{#if group}}{{group}}.{{/if}}{{key}}.group" value="{{group}}">
       <a class="attribute-control" data-action="delete"><i class="fas fa-trash"></i></a>
     </li>
     {{/each}}

--- a/templates/item-sheet.hbs
+++ b/templates/item-sheet.hbs
@@ -41,7 +41,7 @@
       </header>
 
       {{!-- Render the attribute list partial. --}}
-      {{> "systems/laf/templates/item-sheet-attributes.hbs" attributes=system.attributes dtypes=dtypes}}
+      {{> "systems/laf/templates/item-sheet-attributes.hbs" attributes=attributes dtypes=dtypes}}
     </div>
   </section>
 </form>

--- a/templates/sidebar/entity-create.hbs
+++ b/templates/sidebar/entity-create.hbs
@@ -1,16 +1,16 @@
-<form id="entity-create" autocomplete="off" onsubmit="event.preventDefault();">
-    <div class="form-group">
-        <label>{{localize "Name"}}</label>
-        <input type="text" name="name" placeholder="{{localize 'ENTITY.CreateNew'}} {{upper}}"/>
-    </div>
+<form id="entity-create" autocomplete="off">
+  <div class="form-group">
+    <label>{{localize "Name"}}</label>
+    <input type="text" name="name" placeholder="{{localize 'ENTITY.CreateNew'}} {{upper}}" />
+  </div>
 
-    <div class="form-group">
-        <label>{{localize "Type"}}</label>
-        <select name="type">
-        {{#each types}}
-            <option value="{{this.value}}">{{this.label}}</option>
-        {{/each}}
-        </select>
-        <p class="notes">{{localize "ENTITY.TypeHint"}}</p>
-    </div>
+  <div class="form-group">
+    <label>{{localize "Type"}}</label>
+    <select name="type">
+      {{#each types}}
+      <option value="{{this.value}}">{{this.label}}</option>
+      {{/each}}
+    </select>
+    <p class="notes">{{localize "ENTITY.TypeHint"}}</p>
+  </div>
 </form>


### PR DESCRIPTION
Just a small change to fix the 'attributes list' on item sheets, restoring the ability to set the data type, as well as the ability to roll the formula one puts into a 'formula' attribute.

The actor sheet has received an item list appended at the bottom, with items sorted by their `sort` value, next by name.

Also cleaned up some styling issues (some of them subjective, of course).

![image](https://github.com/ElusiveZenith/fvtt-laf/assets/50169243/7c02c34e-7ac7-4d5f-9f92-32b89277c73a)
